### PR TITLE
removes Denite in favor for FZF

### DIFF
--- a/config/nvim/init.vim
+++ b/config/nvim/init.vim
@@ -61,8 +61,6 @@
   Plug 'junegunn/fzf.vim'
 
   " IDE level enhancements
-  Plug 'shougo/denite.nvim'
-  Plug 'chemzqm/denite-git'
   Plug 'Shougo/deoplete.nvim', { 'do': ':UpdateRemotePlugins' }
   Plug 'carlitux/deoplete-ternjs', { 'do': 'npm install -g tern' }
   Plug 'ternjs/tern_for_vim', {'do': 'npm install'}
@@ -180,120 +178,6 @@
   let g:WebDevIconsUnicodeDecorateFileNodesExtensionSymbols['vim'] = ''
 
 " }}}
-
-" Denite -------------------------------------------------------------------{{{
-
-  call denite#custom#option('_', {
-    \ 'prompt': 'λ:',
-    \ 'empty': 0,
-    \ 'winheight': 16,
-    \ 'source_names': 'short',
-    \ 'vertical_preview': 1,
-    \ 'auto-accel': 1,
-    \ 'auto-resume': 1,
-    \ })
-
-  call denite#custom#option('list', {})
-
-  " MATCHERS
-
-  " Default is 'matcher_fuzzy'
-  call denite#custom#source('tag', 'matchers', ['matcher_substring'])
-  if has('nvim') && &runtimepath =~# '\/cpsm'
-   call denite#custom#source(
-    \ 'buffer,file_mru,file_old,file_rec,grep,mpc,line',
-    \ 'matchers', ['matcher_cpsm', 'matcher_fuzzy'])
-  endif
-
-  " CONVERTERS
-  " Default is none
-  call denite#custom#source(
-        \ 'buffer,file_mru,file_old',
-        \ 'converters', ['converter_relative_word'])
-
-  " Ripgrep command on grep source
-  call denite#custom#var('grep', 'command', ['rg'])
-  call denite#custom#var('grep', 'default_opts',
-        \ ['--vimgrep', '--no-heading'])
-  call denite#custom#var('grep', 'recursive_opts', [])
-  call denite#custom#var('grep', 'pattern_opt', ['--regexp'])
-  call denite#custom#var('grep', 'separator', ['--'])
-  call denite#custom#var('grep', 'final_opts', [])
-
-  " KEY MAPPINGS
-  let insert_mode_mappings = [
-        \  ['jj', '<denite:enter_mode:normal>', 'noremap'],
-        \  ['<Esc>', '<denite:enter_mode:normal>', 'noremap'],
-        \  ['<C-N>', '<denite:assign_next_matched_text>', 'noremap'],
-        \  ['<C-P>', '<denite:assign_previous_matched_text>', 'noremap'],
-        \  ['<Up>', '<denite:assign_previous_text>', 'noremap'],
-        \  ['<Down>', '<denite:assign_next_text>', 'noremap'],
-        \  ['<C-Y>', '<denite:redraw>', 'noremap'],
-        \ ]
-
-  let normal_mode_mappings = [
-        \   ["'", '<denite:toggle_select_down>', 'noremap'],
-        \   ['<C-n>', '<denite:jump_to_next_source>', 'noremap'],
-        \   ['<C-p>', '<denite:jump_to_previous_source>', 'noremap'],
-        \   ['gg', '<denite:move_to_first_line>', 'noremap'],
-        \   ['st', '<denite:do_action:tabopen>', 'noremap'],
-        \   ['sg', '<denite:do_action:vsplit>', 'noremap'],
-        \   ['sv', '<denite:do_action:split>', 'noremap'],
-        \   ['sc', '<denite:quit>', 'noremap'],
-        \   ['r', '<denite:redraw>', 'noremap'],
-        \ ]
-
-  for m in insert_mode_mappings
-    call denite#custom#map('insert', m[0], m[1], m[2])
-  endfor
-
-  for m in normal_mode_mappings
-    call denite#custom#map('normal', m[0], m[1], m[2])
-  endfor
-
-  nnoremap <silent><LocalLeader>;r :<C-u>Denite -resume -refresh<CR>
-  nnoremap <silent><LocalLeader>;f :<C-u>Denite file_rec<CR>
-  nnoremap <silent><LocalLeader>;b :<C-u>Denite buffer file_old -default-action=switch<CR>
-  nnoremap <silent><LocalLeader>;d :<C-u>Denite directory_rec -default-action=cd<CR>
-  xnoremap <silent><LocalLeader>;v :<C-u>Denite register -buffer-name=register -default-action=replace<CR>
-  " nnoremap <silent><LocalLeader>;l :<C-u>Denite location_list -buffer-name=list<CR>
-  " nnoremap <silent><LocalLeader>;q :<C-u>Denite quickfix -buffer-name=list<CR>
-  nnoremap <silent><LocalLeader>;g :<C-u>Denite grep<CR>
-  nnoremap <silent><LocalLeader>;j :<C-u>Denite jump change file_point<CR>
-  nnoremap <silent><LocalLeader>;o :<C-u>Denite outline<CR>
-  nnoremap <silent><LocalLeader>;s :<C-u>Denite session -buffer-name=list<CR>
-  nnoremap <silent><expr> <LocalLeader>;t &filetype == 'help' ? "g\<C-]>" :
-        \ ":\<C-u>DeniteCursorWord -buffer-name=tag
-        \  tag:include\<CR>"
-  nnoremap <silent><expr> <LocalLeader>;p  &filetype == 'help' ?
-        \ ":\<C-u>pop\<CR>" : ":\<C-u>Denite -mode=normal jump\<CR>"
-  nnoremap <silent><LocalLeader>;h :<C-u>Denite help<CR>
-  " nnoremap <silent><LocalLeader>m :<C-u>Denite mpc -buffer-name=mpc<CR>
-  nnoremap <silent><LocalLeader>;/ :<C-u>Denite line<CR>
-  nnoremap <silent><LocalLeader>* :<C-u>DeniteCursorWord line<CR>
-  " nnoremap <silent><LocalLeader>z :<C-u>Denite z<CR>
-  nnoremap <silent><LocalLeader>; :<C-u>Denite command command_history<CR>
-
-  " chemzqm/denite-git
-  nnoremap <silent> <Leader>gl :<C-u>Denite gitlog:all<CR>
-  nnoremap <silent> <Leader>gs :<C-u>Denite gitstatus<CR>
-  nnoremap <silent> <Leader>gc :<C-u>Denite gitbranch<CR>
-
-  " Open Denite with word under cursor or selection
-  nnoremap <silent> <Leader>gf :DeniteCursorWord file_rec<CR>
-  nnoremap <silent> <Leader>gg :DeniteCursorWord grep<CR>
-  vnoremap <silent> <Leader>gg
-    \ :<C-u>call <SID>get_selection('/')<CR>
-    \ :execute 'Denite grep:::'.@/<CR><CR>
-
-  function! s:get_selection(cmdtype)
-    let temp = @s
-    normal! gv"sy
-    let @/ = substitute(escape(@s, '\'.a:cmdtype), '\n', '\\n', 'g')
-    let @s = temp
-  endfunction
-
-"}}}
 
 " Deoplete  ----------------------------------------------------------------{{{
 


### PR DESCRIPTION
This PR removes Denite from the neovim config. The denite config will still exist in a branch called `legacy-denite`